### PR TITLE
feature/abort-to-lobby

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/model/game/Game.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/model/game/Game.java
@@ -27,8 +27,8 @@ public class Game {
         this.status = GameStatus.LOBBY;
         this.currentPhase = TurnPhase.WAITING_FOR_ROLL;
         this.players = new ArrayList<>();
-        this.board = board.getINSTANCE();
-        this.turnManager = turnManager.getINSTANCE();
+        this.board = Board.getINSTANCE();
+        this.turnManager = TurnManager.getINSTANCE();
         this.deck = new Deck();
     }
 
@@ -37,8 +37,8 @@ public class Game {
         this.status = GameStatus.LOBBY;
         this.currentPhase = TurnPhase.WAITING_FOR_ROLL;
         this.players = new ArrayList<>();
-        this.board = board.getINSTANCE();
-        this.turnManager = turnManager.getINSTANCE();
+        this.board = Board.getINSTANCE();
+        this.turnManager = TurnManager.getINSTANCE();
         this.caseFile = null;
     }
 
@@ -100,6 +100,7 @@ public class Game {
         this.status = GameStatus.RUNNING;
         this.currentPhase = TurnPhase.WAITING_FOR_ROLL;
         this.turnManager = TurnManager.getINSTANCE();
+        this.turnManager.reset();
         this.deck = new Deck();
         this.caseFile = deck.createCaseFile();
         this.deck.dealCards(this.players);
@@ -114,11 +115,29 @@ public class Game {
     }
 
     public void abort() {
-        this.status = GameStatus.ABORTED;
+        //this.status = GameStatus.ABORTED;
 
         if (this.caseFile != null) {
             this.caseFile.clear();
         }
+        this.currentPhase = TurnPhase.WAITING_FOR_ROLL;
+        this.caseFile = null;
+        this.deck = new Deck();
+
+        for(Player player : players) {
+            player.setReady(false);
+            player.setCharacter(null);
+            player.setCards(null);
+            player.setCurrentPosition(null);
+            player.setEliminated(false);
+            player.setCheatUsed(false);
+            player.setAccusationUsed(false);
+            player.setActive(true);
+        }
+        this.turnManager = TurnManager.getINSTANCE();
+        this.turnManager.reset();
+
+        this.status = GameStatus.LOBBY;
     }
 
     public void makeSuggestion() {

--- a/src/main/java/at/aau/serg/websocketdemoserver/model/game/TurnManager.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/model/game/TurnManager.java
@@ -17,6 +17,12 @@ public class TurnManager {
     private int diceValue;
     private int movesRemaining;
     private TurnPhase phase;
+    public void reset() {
+        this.currentPlayerIndex = 0;
+        this.diceValue = 0;
+        this.movesRemaining = 0;
+        this.phase = TurnPhase.WAITING_FOR_ROLL;
+    }
 
     private TurnManager() {
         this.phase = TurnPhase.WAITING_FOR_ROLL;

--- a/src/main/java/at/aau/serg/websocketdemoserver/server/GameServer.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/server/GameServer.java
@@ -607,12 +607,11 @@ public class GameServer {
                 );
 
                 if (game.allPlayersEliminated()) {
-                  dbService.updateGameStatus(game.getStatus().toString(), game.getCurrentPhase().toString());
-
                     response.put("type", GameMessageType.GAME_ABORTED.toString());
                     responsePayload.put("reason", "All players eliminated");
 
                     game.abort();
+                    dbService.updateGameStatus(game.getStatus().toString(), game.getCurrentPhase().toString());
                     addLobbyResetPayload(responsePayload, game);
 
                 } else {

--- a/src/main/java/at/aau/serg/websocketdemoserver/server/GameServer.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/server/GameServer.java
@@ -528,9 +528,12 @@ public class GameServer {
                 accuser.eliminate();
 
                 if (game.allPlayersEliminated()) {
-                    game.abort();
                     response.put("type", GameMessageType.GAME_ABORTED.toString());
                     responsePayload.put("reason", "All players eliminated");
+
+                    game.abort();
+                    addLobbyResetPayload(responsePayload, game);
+
                 } else {
                     response.put("type", GameMessageType.MAKE_ACCUSATION.toString());
                     responsePayload.put("eliminated", true);
@@ -641,6 +644,31 @@ public class GameServer {
 
         response.set("payload", responsePayload);
         return response;
+    }
+    private void addLobbyResetPayload(ObjectNode responsePayload, Game game) {
+        responsePayload.put("status", game.getStatus().toString());
+        responsePayload.put("currentPhase", game.getCurrentPhase().toString());
+
+        ArrayNode availableCharacters = mapper.createArrayNode();
+        for (CharacterType c : game.getAvailableCharacters()) {
+            availableCharacters.add(c.toString());
+        }
+        responsePayload.set("availableCharacters", availableCharacters);
+
+        ArrayNode existingPlayers = mapper.createArrayNode();
+        for (Player p : game.getPlayers()) {
+            ObjectNode playerNode = mapper.createObjectNode();
+            playerNode.put("playerId", p.getPlayerId());
+            playerNode.put("ready", p.isReady());
+
+            if (p.getCharacter() != null) {
+                playerNode.put("characterType", p.getCharacter().toString());
+            }
+
+            existingPlayers.add(playerNode);
+        }
+
+        responsePayload.set("existingPlayers", existingPlayers);
     }
 
     private Player findPlayer(Game game, String playerId) {

--- a/src/test/java/at/aau/serg/websocketdemoserver/model/game/GameTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/model/game/GameTest.java
@@ -214,7 +214,7 @@ public class GameTest {
         game.abort();
 
         assertEquals(GameStatus.LOBBY, game.getStatus());
-        assertFalse(game.getCaseFile().isComplete());
+        assertNull(game.getCaseFile());
     }
 
     @Test

--- a/src/test/java/at/aau/serg/websocketdemoserver/model/game/GameTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/model/game/GameTest.java
@@ -213,7 +213,7 @@ public class GameTest {
 
         game.abort();
 
-        assertEquals(GameStatus.ABORTED, game.getStatus());
+        assertEquals(GameStatus.LOBBY, game.getStatus());
         assertFalse(game.getCaseFile().isComplete());
     }
 


### PR DESCRIPTION
Reset game state and return players to lobby after game abort.

- reset game and player state after abort
- change game status back to LOBBY
- send updated lobby data in GAME_ABORTED payload
- handle GAME_ABORTED 
- return all players back to the lobby
- allow players to choose a new character and setReady again